### PR TITLE
add basic support for video recording

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 audio
+data
 text/**
 .DS_Store
 .vscode

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is a simple web application to aid with collection of labelled speech sampl
 - [ ] Proper configuration secret storage
 - [ ] Ensure proper Flask app structure (blueprints, etc)
 - [ ] Test cases 
-- [ ] Store audio files in S3 or Google Cloud Storage 
+- [ ] Store audio/video files in S3 or Google Cloud Storage 
 - [ ] Better UI (possible transition to React)
 - [ ] Admin console (nice-to-have)
 
@@ -24,7 +24,7 @@ This is a simple web application to aid with collection of labelled speech sampl
 If you require additional text to generate speech samples from, simply add a new `txt` file in the `text/` directory
 
 ## Collecting Data
-All audio samples will be placed in a `audio/` directory, where each subdirectory is a user's UUID, and each file inside `audio/<user UUID>` is a file of form `<name of text>.wav`
+All audio/video samples will be placed in a `data/` directory, where each subdirectory is a user's UUID, and each file inside `data/<user UUID>` is a file of form `<name of text>.webm`
 
 ## Installation
 Simply clone this repo, install dependencies, and run the app with `gunicorn --bind 0.0.0.0:80 wsgi:app`

--- a/config.py
+++ b/config.py
@@ -3,3 +3,4 @@ import os
 
 class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY") or "DEVELOPMENT_KEY"
+    MAX_CONTENT_LENGTH = 1024 * 1024 * 1024

--- a/helpers.py
+++ b/helpers.py
@@ -65,4 +65,4 @@ def init_db():
 
 def init_dirs():
     Path("text").mkdir(parents=True, exist_ok=True)
-    Path("audio").mkdir(parents=True, exist_ok=True)
+    Path("data").mkdir(parents=True, exist_ok=True)

--- a/main.py
+++ b/main.py
@@ -45,6 +45,8 @@ login_manager.init_app(app)
 init_db()
 init_dirs()
 
+DATA_DIR = "data"
+
 
 @login_manager.user_loader
 def user_loader(user_id):
@@ -148,19 +150,21 @@ def text_detail(text):
 @app.route("/text/<string:text>/upload", methods=["POST"])
 @login_required
 def text_upload(text):
-    audio_data = request.files.to_dict().get("audio_data")
-    if not audio_data:
+    data = request.files.to_dict().get("data")
+    if not data:
         return jsonify(success=False)
 
-    Path(f"audio/{current_user.id}").mkdir(parents=True, exist_ok=True)
+    Path(f"{DATA_DIR}/{current_user.id}").mkdir(parents=True, exist_ok=True)
     if text == "blank":
-        files = os.listdir(f"audio/{current_user.id}")
+        files = os.listdir(f"{DATA_DIR}/{current_user.id}")
         num_blanks = len([f for f in files if "blank" in f])
         text_name = f"blank-{num_blanks + 1}"
+        data.save(f"{DATA_DIR}/{current_user.id}/{text_name}.webm")
+        UserRecording.create(user=current_user.id, audio_path=None)
     else:
         text_name = text.split(".")[0]
-    audio_data.save(f"audio/{current_user.id}/{text_name}.wav")
-    UserRecording.create(user=current_user.id, audio_path=text)
+        data.save(f"{DATA_DIR}/{current_user.id}/{text_name}.wav")
+        UserRecording.create(user=current_user.id, audio_path=text)
 
     return jsonify(success=True)
 

--- a/models.py
+++ b/models.py
@@ -28,5 +28,5 @@ class User(BaseModel, UserMixin):
 
 class UserRecording(BaseModel):
     user = ForeignKeyField(User, backref="recordings")
-    audio_path = CharField()
+    audio_path = CharField(null=True)
     created_at = DateTimeField(default=datetime.now)

--- a/static/js/audio.js
+++ b/static/js/audio.js
@@ -1,0 +1,162 @@
+function gotDevices(deviceInfos) {
+    for (let i = 0; i !== deviceInfos.length; ++i) {
+        const deviceInfo = deviceInfos[i];
+        const option = document.createElement("option");
+        option.value = deviceInfo.deviceId;
+        if (deviceInfo.kind === "audioinput") {
+            option.text =
+                deviceInfo.label || "microphone " + (audioSelect.length + 1);
+            audioSelect.appendChild(option);
+        } else if (deviceInfo.kind === "videoinput") {
+            option.text = deviceInfo.label || "camera " + (videoSelect.length + 1);
+            videoSelect.appendChild(option);
+            videoSelect.value = deviceInfo.deviceId
+        }
+    }
+}
+
+function getStream() {
+    if (window.stream) {
+        window.stream.getTracks().forEach(function(track) {
+            track.stop();
+        });
+    }
+    const constraints = {
+        audio: {
+            deviceId: {
+                exact: audioSelect.value
+            },
+        },
+        video: {
+            deviceId: {
+                exact: videoSelect.value
+            },
+            width: {
+                exact: 640
+            },
+            height: {
+                exact: 480
+            }
+        },
+    };
+
+
+    navigator.mediaDevices
+        .getUserMedia(constraints)
+        .then(gotStream)
+        .catch(handleError);
+}
+
+function gotStream(stream) {
+    window.stream = stream;
+    videoElement.srcObject = stream;
+}
+
+function handleError(error) {
+    console.error("Error: ", error);
+}
+
+
+
+const delay = ms => new Promise(res => setTimeout(res, ms));
+
+function stopRecording() {
+    mediaRecorder.stop();
+    audioSelect.disabled = false;
+    videoSelect.disabled = false;
+    startButton.disabled = false;
+    endButton.disabled = true;
+}
+
+
+const video = document.querySelector("video");
+
+const videoElement = document.querySelector("video");
+const audioSelect = document.querySelector("select#audioSource");
+const videoSelect = document.querySelector("select#videoSource");
+
+const startButton = document.querySelector("button#start")
+const endButton = document.querySelector("button#end")
+endButton.disabled = true;
+
+var mediaRecorder;
+var recordedChunks = [];
+
+function startRecording() {
+    audioSelect.disabled = true;
+    videoSelect.disabled = true;
+    startButton.disabled = true;
+    endButton.disabled = false;
+
+    const constraints = {
+        audio: {
+            deviceId: {
+                exact: audioSelect.value
+            },
+        },
+        video: {
+            deviceId: {
+                exact: videoSelect.value
+            },
+            width: {
+                exact: 640
+            },
+            height: {
+                exact: 480
+            }
+        },
+    };
+    navigator.getUserMedia(constraints, stream => {
+        mediaRecorder = new MediaRecorder(stream);
+        const options = {
+            mimeType: 'video/webm;codecs=vp9'
+        };
+        mediaRecorder.ondataavailable = event => {
+            if (event.data.size > 0) {
+                recordedChunks.push(event.data)
+            } else {}
+        };
+        mediaRecorder.onstop = e => {
+            let blob = new Blob(recordedChunks, {
+                'type': 'video/mp4'
+            })
+            let videoURL = window.URL.createObjectURL(blob)
+
+            createDownloadLink(blob)
+            recordedChunks = []
+        }
+        mediaRecorder.start();
+
+
+    }, e => console.log(e))
+}
+
+navigator.mediaDevices
+    .enumerateDevices()
+    .then(gotDevices)
+    .then(getStream)
+    .catch(handleError);
+
+audioSelect.onchange = getStream;
+videoSelect.onchange = getStream;
+
+function createDownloadLink(blob) {
+    var url = URL.createObjectURL(blob);
+    var link = document.createElement('a');
+
+    link.href = url;
+    link.download = new Date().toISOString() + '.webm';
+    link.innerHTML = link.download;
+
+    var filename = new Date().toISOString();
+    var xhr = new XMLHttpRequest();
+    xhr.onload = function(e) {
+        if (this.readyState === 4) {
+            console.log("Server returned: ", e.target.responseText);
+        }
+    };
+    var fd = new FormData();
+    fd.append("data", blob, filename);
+    xhr.open("POST", "/text/blank/upload", true);
+    xhr.send(fd);
+}

--- a/templates/blank_text.html
+++ b/templates/blank_text.html
@@ -9,111 +9,19 @@
             <div>
                 <p>Welcome, {{ current_user.email }} </p>
 
-            <div id="inner">
-                <button id="recordButton">Record</button>
-                <button id="pauseButton" disabled>Pause</button>
-                <button id="stopButton" disabled>Stop</button>
+            <div>
+                <video muted autoplay></video>
+                <select id="audioSource"></select>
+                <select id="videoSource"></select>
+            </div>
+            <div>
+                <button id="start" onclick="startRecording()">Start</button>
+                <button id="end" onclick="stopRecording()">End</button>
             </div>
         </div>
         <a class="backlink" href="/home">&gt;All Texts</a>
     </body>
 
-    {% block javascript %}
-        <script>
-            URL = window.URL
-            var gumStream;
-            var rec;
-            var input;
-
-            var AudioContext = window.AudioContext || window.webkitAudioContext;
-            var audioContext = new AudioContext;
-
-            var recordButton = document.getElementById("recordButton");
-            var stopButton = document.getElementById("stopButton");
-            var pauseButton = document.getElementById("pauseButton");
-
-            recordButton.addEventListener("click", startRecording);
-            stopButton.addEventListener("click", stopRecording);
-            pauseButton.addEventListener("click", pauseRecording);
-
-            function startRecording() {
-                var constraints = {
-                    audio: true,
-                    video: false
-                } 
-
-                recordButton.disabled = true;
-                stopButton.disabled = false;
-                pauseButton.disabled = false
-
-                navigator.mediaDevices.getUserMedia(constraints).then(function(stream) {
-                    console.log("getUserMedia() success, stream created, initializing Recorder.js ..."); 
-                    gumStream = stream;
-                    input = audioContext.createMediaStreamSource(stream);
-                    rec = new Recorder(input, {
-                        numChannels: 1
-                    }) 
-                    rec.record()
-                    console.log("Recording started");
-                }).catch(function(err) {
-                    recordButton.disabled = false;
-                    stopButton.disabled = true;
-                    pauseButton.disabled = true
-                });
-            }
-
-            function pauseRecording() {
-                console.log("pauseButton clicked rec.recording=", rec.recording);
-                if (rec.recording) {
-                    rec.stop();
-                    pauseButton.innerHTML = "Resume";
-                } else {
-                    rec.record()
-                    pauseButton.innerHTML = "Pause";
-                }
-            }
-
-            function stopRecording() {
-                console.log("stopButton clicked");
-                stopButton.disabled = true;
-                recordButton.disabled = false;
-                pauseButton.disabled = true;
-                pauseButton.innerHTML = "Pause";
-                rec.stop();
-                gumStream.getAudioTracks()[0].stop();
-                rec.exportWAV(createDownloadLink);
-            }
-
-            function getRandomInt(max) {
-                return Math.floor(Math.random() * Math.floor(max));
-            }
-
-            function createDownloadLink(blob) {
-                var url = URL.createObjectURL(blob);
-                var au = document.createElement('audio');
-                var link = document.createElement('a');
-
-                au.controls = true;
-                au.src = url;
-
-                link.href = url;
-                link.download = new Date().toISOString() + '.wav';
-                link.innerHTML = link.download;
-
-                var filename = new Date().toISOString();
-                var xhr = new XMLHttpRequest();
-                xhr.onload = function(e) {
-                    if (this.readyState === 4) {
-                        console.log("Server returned: ", e.target.responseText);
-                    }
-                };
-                var fd = new FormData();
-                fd.append("audio_data", blob, filename);
-                xhr.open("POST", "/text/blank/upload", true);
-                xhr.send(fd);
-            }
-        </script>
-    {% endblock %}
-
+    <script src="{{ url_for('static', filename='js/audio.js') }}"></script>
     <script src="https://cdn.rawgit.com/mattdiamond/Recorderjs/08e7abd9/dist/recorder.js"></script>
 </html>

--- a/templates/text.html
+++ b/templates/text.html
@@ -22,7 +22,6 @@
 
             <div id="inner">
                 <button id="recordButton">Record</button>
-                <button id="pauseButton" disabled>Pause</button>
                 <button id="stopButton" disabled>Stop</button>
             </div>
         </div>
@@ -41,11 +40,9 @@
 
             var recordButton = document.getElementById("recordButton");
             var stopButton = document.getElementById("stopButton");
-            var pauseButton = document.getElementById("pauseButton");
 
             recordButton.addEventListener("click", startRecording);
             stopButton.addEventListener("click", stopRecording);
-            pauseButton.addEventListener("click", pauseRecording);
 
             function startRecording() {
                 var constraints = {
@@ -55,7 +52,6 @@
 
                 recordButton.disabled = true;
                 stopButton.disabled = false;
-                pauseButton.disabled = false
 
                 navigator.mediaDevices.getUserMedia(constraints).then(function(stream) {
                     console.log("getUserMedia() success, stream created, initializing Recorder.js ..."); 
@@ -69,27 +65,14 @@
                 }).catch(function(err) {
                     recordButton.disabled = false;
                     stopButton.disabled = true;
-                    pauseButton.disabled = true
                 });
             }
 
-            function pauseRecording() {
-                console.log("pauseButton clicked rec.recording=", rec.recording);
-                if (rec.recording) {
-                    rec.stop();
-                    pauseButton.innerHTML = "Resume";
-                } else {
-                    rec.record()
-                    pauseButton.innerHTML = "Pause";
-                }
-            }
 
             function stopRecording() {
                 console.log("stopButton clicked");
                 stopButton.disabled = true;
                 recordButton.disabled = false;
-                pauseButton.disabled = true;
-                pauseButton.innerHTML = "Pause";
                 rec.stop();
                 gumStream.getAudioTracks()[0].stop();
                 rec.exportWAV(createDownloadLink);
@@ -115,7 +98,7 @@
                     }
                 };
                 var fd = new FormData();
-                fd.append("audio_data", blob, filename);
+                fd.append("data", blob, filename);
                 xhr.open("POST", "/text/{{ text_detail.name }}/upload", true);
                 xhr.send(fd);
             }


### PR DESCRIPTION
this was all implemented on the blank text
page. currently there is no option to enable/disable
video, that will come in a future change.

additionally, change all instances of `audio/` folder
to `data/` as that makes more sense

Adds basic ability to toggle between audio and video
input devices.

<img width="977" alt="Screen Shot 2020-11-24 at 2 47 00 PM" src="https://user-images.githubusercontent.com/3424647/100149513-ef845800-2e63-11eb-872c-5f4426390f7d.png">